### PR TITLE
add compile parameters to header file

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pdcurses" %}
 {% set version = "3.9" %}
+{% set posix = 'm2-' if win else '' %}
 
 package:
   name: {{ name|lower }}
@@ -8,16 +9,19 @@ package:
 source:
   url: https://github.com/wmcbrine/PDCurses/archive/refs/tags/{{ version }}.tar.gz
   sha256: 590dbe0f5835f66992df096d3602d0271103f90cf8557a5d124f693c2b40d7ec
+  patches:
+    - set-build-params.patch  # [win]
 
 build:
   skip: True  # [not win]
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage('pdcurses', max_pin='x.x') }}
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ posix }}patch
   host:
 
   run:

--- a/recipe/set-build-params.patch
+++ b/recipe/set-build-params.patch
@@ -1,0 +1,28 @@
+diff -ru a/curses.h b/curses.h
+--- a/curses.h	2019-09-04 22:08:02.000000000 +0200
++++ b/curses.h	2021-11-22 13:24:10.615798200 +0100
+@@ -43,6 +43,11 @@
+ # define PDC_PP98       1
+ #endif
+ 
++/* Conda-Forge build settings*/
++#define PDC_WIDE
++#define PDC_FORCE_UTF8
++#define PDC_DLL_BUILD
++
+ /*----------------------------------------------------------------------*/
+ 
+ #include <stdarg.h>
+diff -ru a/wincon/Makefile.vc b/wincon/Makefile.vc
+--- a/wincon/Makefile.vc	2019-09-04 22:08:02.000000000 +0200
++++ b/wincon/Makefile.vc	2021-11-22 13:28:43.120998800 +0100
+@@ -21,7 +21,8 @@
+ 
+ PDCURSES_WIN_H	= $(osdir)\pdcwin.h
+ 
+-CC		= cl.exe -nologo
++# disable warning C4005 (macro redefinition)
++CC		= cl.exe -nologo /wd4005
+ 
+ !ifdef DEBUG
+ CFLAGS		= -Z7 -DPDCDEBUG


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
We compile using certain flags, which applications currently have to explicitly set before including `curses.h`.
As of this PR, the flags are put into the header file itself using a small patch.